### PR TITLE
Create door

### DIFF
--- a/webgame-game/Cargo.lock
+++ b/webgame-game/Cargo.lock
@@ -4032,9 +4032,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4042,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -4069,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4079,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4092,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wayland-client"

--- a/webgame-game/src/configs.rs
+++ b/webgame-game/src/configs.rs
@@ -12,6 +12,7 @@ use crate::{
     gridworld::{GridworldPlayPlugin, GridworldPlugin},
     net::NetPlugin,
     observer::{ObserverPlayPlugin, ObserverPlugin},
+    world_objs::{WorldObjPlayPlugin, WorldObjPlugin},
 };
 
 /// Handles core functionality for our game (i.e. gameplay logic).
@@ -20,7 +21,7 @@ pub struct CoreGamePlugin;
 impl Plugin for CoreGamePlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
-            .add_plugins((NetPlugin, GridworldPlugin, ObserverPlugin));
+            .add_plugins((NetPlugin, GridworldPlugin, ObserverPlugin, WorldObjPlugin));
     }
 }
 
@@ -39,7 +40,7 @@ impl Plugin for PlayablePlugin {
                 ..default()
             }))
             .add_plugins(RapierDebugRenderPlugin::default())
-            .add_plugins((GridworldPlayPlugin, ObserverPlayPlugin));
+            .add_plugins((GridworldPlayPlugin, ObserverPlayPlugin, WorldObjPlayPlugin));
     }
 }
 

--- a/webgame-game/src/gridworld.rs
+++ b/webgame-game/src/gridworld.rs
@@ -4,7 +4,7 @@ use bevy_rapier2d::{
 };
 use rand::Rng;
 
-use crate::observer::{DebugObserver, Observable, Observer, Wall};
+use crate::{observer::{DebugObserver, Observable, Observer, Wall}, world_objs::Door};
 
 /// Plugin for basic game features, such as moving around and not going through walls.
 pub struct GridworldPlugin;
@@ -34,7 +34,10 @@ impl Plugin for GridworldPlayPlugin {
     }
 }
 
+/// The width and height of the level by default.
 pub const DEFAULT_LEVEL_SIZE: usize = 8;
+/// The probability of a door spawning in an empty cell.
+pub const DOOR_PROB: f64 = 0.05;
 
 /// Stores the layout of the level.
 #[derive(Resource)]
@@ -102,7 +105,8 @@ fn setup_entities(mut commands: Commands, level: Res<LevelLayout>) {
         DebugObserver,
     ));
 
-    // Set up walls
+    // Set up walls and doors
+    let mut rng = rand::thread_rng();
     for y in 0..level.size {
         for x in 0..level.size {
             if level.walls[y * level.size + x] {
@@ -112,6 +116,15 @@ fn setup_entities(mut commands: Commands, level: Res<LevelLayout>) {
                     TransformBundle::from_transform(Transform::from_translation(
                         Vec3::new(x as f32, (level.size - y - 1) as f32, 0.) * GRID_CELL_SIZE,
                     )),
+                ));
+            }
+            else if rng.gen_bool(DOOR_PROB) {
+                commands.spawn((
+                    Door::default(),
+                    Collider::cuboid(GRID_CELL_SIZE / 2., GRID_CELL_SIZE / 2.),
+                    TransformBundle::from_transform(Transform::from_translation(
+                        Vec3::new(x as f32, (level.size - y - 1) as f32, 0.) * GRID_CELL_SIZE,
+                    )), 
                 ));
             }
         }
@@ -135,7 +148,7 @@ fn setup_entities(mut commands: Commands, level: Res<LevelLayout>) {
     }
 }
 
-const GRID_CELL_SIZE: f32 = 25.;
+pub const GRID_CELL_SIZE: f32 = 25.;
 
 /// Sets up entities for playable mode.
 fn setup_entities_playable(mut commands: Commands, level: Res<LevelLayout>) {

--- a/webgame-game/src/gridworld.rs
+++ b/webgame-game/src/gridworld.rs
@@ -4,7 +4,10 @@ use bevy_rapier2d::{
 };
 use rand::Rng;
 
-use crate::{observer::{DebugObserver, Observable, Observer, Wall}, world_objs::Door};
+use crate::{
+    observer::{DebugObserver, Observable, Observer, Wall},
+    world_objs::Door,
+};
 
 /// Plugin for basic game features, such as moving around and not going through walls.
 pub struct GridworldPlugin;
@@ -117,14 +120,13 @@ fn setup_entities(mut commands: Commands, level: Res<LevelLayout>) {
                         Vec3::new(x as f32, (level.size - y - 1) as f32, 0.) * GRID_CELL_SIZE,
                     )),
                 ));
-            }
-            else if rng.gen_bool(DOOR_PROB) {
+            } else if rng.gen_bool(DOOR_PROB) {
                 commands.spawn((
                     Door::default(),
                     Collider::cuboid(GRID_CELL_SIZE / 2., GRID_CELL_SIZE / 2.),
                     TransformBundle::from_transform(Transform::from_translation(
                         Vec3::new(x as f32, (level.size - y - 1) as f32, 0.) * GRID_CELL_SIZE,
-                    )), 
+                    )),
                 ));
             }
         }
@@ -238,6 +240,8 @@ const AGENT_SPEED: f32 = GRID_CELL_SIZE * 2.;
 pub struct NextAction {
     /// Which direction the agent will move in.
     pub dir: Vec2,
+    /// Whether the agent should toggle nearby objects this frame.
+    pub toggle_objs: bool,
 }
 
 /// Allows the player to set the Players next action.
@@ -260,6 +264,10 @@ fn set_player_action(
     }
     let mut next_action = player_query.single_mut();
     next_action.dir = dir;
+    next_action.toggle_objs = false;
+    if inpt.just_pressed(KeyCode::F) {
+        next_action.toggle_objs = true;
+    }
 }
 
 /// Moves agents around.

--- a/webgame-game/src/lib.rs
+++ b/webgame-game/src/lib.rs
@@ -2,3 +2,4 @@ pub mod net;
 pub mod configs;
 pub mod gridworld;
 pub mod observer;
+pub mod world_objs;

--- a/webgame-game/src/main.rs
+++ b/webgame-game/src/main.rs
@@ -5,6 +5,7 @@ mod net;
 mod configs;
 mod gridworld;
 mod observer;
+mod world_objs;
 
 /// Main entry point for our game.
 fn main() {

--- a/webgame-game/src/world_objs.rs
+++ b/webgame-game/src/world_objs.rs
@@ -1,0 +1,66 @@
+use crate::{gridworld::GRID_CELL_SIZE, observer::Wall};
+use bevy::prelude::*;
+
+/// Plugin for world objects (e.g. doors, noise sources).
+pub struct WorldObjPlugin;
+
+impl Plugin for WorldObjPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, update_door);
+    }
+}
+
+/// Adds playable functionality for `WorldObjPlugin`.
+pub struct WorldObjPlayPlugin;
+
+impl Plugin for WorldObjPlayPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, visualize_door);
+    }
+}
+
+/// A door that can be opened and closed.
+#[derive(Component, Default)]
+pub struct Door {
+    pub open: bool,
+}
+
+/// Opens and closes the door.
+fn update_door(mut commands: Commands, door_query: Query<(Entity, &Door), Changed<Door>>) {
+    for (e, door) in door_query.iter() {
+        if door.open {
+            commands.entity(e).remove::<Wall>();
+        } else {
+            commands.entity(e).insert(Wall);
+        }
+    }
+}
+
+/// Updates the door visual.
+fn visualize_door(
+    mut commands: Commands,
+    mut door_query: Query<(Entity, &Door, Option<&mut Sprite>), Changed<Door>>,
+) {
+    for (e, door, sprite) in door_query.iter_mut() {
+        if door.open {
+            sprite.unwrap().color.set_a(0.5);
+            commands.entity(e).remove::<Wall>();
+        } else if let Some(mut sprite) = sprite {
+            sprite.color.set_a(1.);
+            commands.entity(e).insert(Wall);
+        } else {
+            commands.entity(e).insert((
+                Sprite {
+                    color: Color::MAROON,
+                    custom_size: Some(Vec2::ONE * GRID_CELL_SIZE),
+                    ..default()
+                },
+                Handle::<Image>::default(),
+                Visibility::Visible,
+                InheritedVisibility::default(),
+                ViewVisibility::default(),
+            ));
+            commands.entity(e).insert(Wall);
+        }
+    }
+}

--- a/webgame-ml/webgame/envs.py
+++ b/webgame-ml/webgame/envs.py
@@ -80,7 +80,7 @@ class GameEnv(pettingzoo.ParallelEnv):
 
     @functools.lru_cache(maxsize=None)
     def action_space(self, _: str) -> gym.Space:
-        return gym.spaces.Discrete(9)
+        return gym.spaces.Discrete(10)
 
     @functools.lru_cache(maxsize=None)
     def observation_space(self, _: str) -> gym.Space:

--- a/webgame-ml/webgame_rust/src/lib.rs
+++ b/webgame-ml/webgame_rust/src/lib.rs
@@ -79,6 +79,7 @@ pub enum AgentAction {
     MoveDownLeft = 6,
     MoveLeft = 7,
     MoveUpLeft = 8,
+    ToggleObj = 9,
 }
 
 impl<'source> FromPyObject<'source> for AgentAction {
@@ -139,6 +140,7 @@ fn set_agent_action<T: Component>(world: &mut World, action: AgentAction) {
         AgentAction::MoveUpLeft => (Vec2::Y + -Vec2::X).normalize(),
         _ => Vec2::ZERO,
     };
+    action.toggle_obj = action == AgentAction::ToggleObj;
 }
 
 /// Queries the world for an agent with the provided component and returns an `AgentState`.


### PR DESCRIPTION
Adds the door object. Doors can be toggled by agents within a certain range to open and close it. Closing a door prevents agents from seeing and moving through it.

When playing the game, use "F" to toggle doors.

![Recording 2024-03-23 at 18 31 15](https://github.com/Boxxfish/pursuer-demo/assets/24901846/309622f2-a1f1-4f8c-893d-9084968ab575)
